### PR TITLE
Fixed Redownload Book

### DIFF
--- a/app/src/main/java/moe/feng/nhentai/api/PageApi.java
+++ b/app/src/main/java/moe/feng/nhentai/api/PageApi.java
@@ -285,9 +285,8 @@ public class PageApi {
     }
 
 	public static boolean isPageOriginImageLocalFileExist(Context context, Book book, int page_num) {
-		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
-
-		return FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url, book.title);
+        Log.d(TAG, "isPageOriginImageLocalFileExist: "+ FileCacheManager.getInstance(context).externalPageExists(book,page_num));
+        return FileCacheManager.getInstance(context).externalPageExists(book,page_num);
 	}
 
 }


### PR DESCRIPTION
Overall: Fixed Saving, Deleting and ReDownloading Books

PageAPI -> Properly check downloaded images on external instead of cache