### PR TITLE
Hotfix Settings Activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
 		applicationId "moe.feng.nhentai"
 		minSdkVersion 17
 		targetSdkVersion 24
-		versionCode 21
-		versionName "1.4.0"
+		versionCode 22
+		versionName "1.4.1"
 	}
 	buildTypes {
 		release {
@@ -21,11 +21,11 @@ android {
 
 dependencies {
 	compile fileTree(dir: 'libs', include: ['*.jar'])
-	compile 'com.android.support:support-v13:24.1.0'
-	compile 'com.android.support:design:24.1.0'
-	compile 'com.android.support:appcompat-v7:24.1.0'
-	compile 'com.android.support:cardview-v7:24.1.0'
-	compile 'com.android.support:recyclerview-v7:24.1.0'
+	compile 'com.android.support:support-v13:24.1.1'
+	compile 'com.android.support:design:24.1.1'
+	compile 'com.android.support:appcompat-v7:24.1.1'
+	compile 'com.android.support:cardview-v7:24.1.1'
+	compile 'com.android.support:recyclerview-v7:24.1.1'
 	compile 'com.google.code.gson:gson:2.4'
 	compile 'org.jsoup:jsoup:1.8.2'
 	compile 'com.github.chrisbanes.photoview:library:1.2.3'

--- a/app/src/main/java/moe/feng/nhentai/ui/fragment/settings/SettingsStorage.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/fragment/settings/SettingsStorage.java
@@ -19,7 +19,7 @@ public class SettingsStorage extends PreferenceFragment implements Preference.On
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.settings_storage);
 
-		mSets = Settings.getInstance(getContext());
+		mSets = Settings.getInstance(getParentActivity().getBaseContext());
 
 		getActivity().setTitle(R.string.settings_storage);
 


### PR DESCRIPTION
Overall: Fixed aForce Close on Settings Activity on Android 4.x

SettingsStorage -> Get the activity context, not the fragment context

Build Gradle -> Update Google libs and bumped version to 1.4.1 (22)