### PR TITLE
Hotfix Array Check in Layout Manager

### DIFF
--- a/app/src/main/java/moe/feng/nhentai/ui/CategoryActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/CategoryActivity.java
@@ -146,7 +146,7 @@ public class CategoryActivity extends AbsActivity {
 			isFavorite = !isFavorite;
 			Snackbar.make(
 					mPager,
-					isFavorite ? R.string.favorite_add_finished : R.string.favorite_remove_finished,
+					isFavorite ? R.string.favorite_categories_add_finished : R.string.favorite_categories_remove_finished,
 					Snackbar.LENGTH_LONG
 			).show();
 			invalidateOptionsMenu();

--- a/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
@@ -752,7 +752,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 			@Override
 			public void onScrolled(RecyclerView rv, int dx, int dy) {
 				super.onScrolled(rv, dx, dy);
-				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[1] >= mAdapter.getItemCount() - 2) {
+				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[0] >= mAdapter.getItemCount() - 2) {
 					mSwipeRefreshLayout.setRefreshing(true);
 					new PageGetTask().execute(++mNowPage);
 				}

--- a/app/src/main/java/moe/feng/nhentai/ui/SearchActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/SearchActivity.java
@@ -214,7 +214,7 @@ public class SearchActivity extends AbsActivity {
 		adapter.addOnScrollListener(new RecyclerView.OnScrollListener() {
 			@Override
 			public void onScrolled(RecyclerView rv, int dx, int dy) {
-				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[1] >= mAdapter.getItemCount() - 2) {
+				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[0] >= mAdapter.getItemCount() - 2) {
 					mSwipeRefreshLayout.setRefreshing(true);
 					++mNowPage;
 					new PageGetTask().execute(getApplicationContext());

--- a/app/src/main/java/moe/feng/nhentai/ui/fragment/PageListFragment.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/fragment/PageListFragment.java
@@ -124,7 +124,7 @@ public class PageListFragment extends LazyFragment {
 		adapter.addOnScrollListener(new RecyclerView.OnScrollListener() {
 			@Override
 			public void onScrolled(RecyclerView rv, int dx, int dy) {
-				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[1] >= mAdapter.getItemCount() - 2) {
+				if (!mSwipeRefreshLayout.isRefreshing() && mLayoutManager.findLastCompletelyVisibleItemPositions(new int[mHorCardCount])[0] >= mAdapter.getItemCount() - 2) {
 					if (!isAllowToLoadNextPage) return;
 					mSwipeRefreshLayout.setRefreshing(true);
 					new PageGetTask().execute(++mNowPage);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,9 @@
     <string name="action_favorite_false">Add to favorites</string>
     <string name="action_favorite_true">Remove from favorites</string>
     <string name="favorite_add_finished">The book successfully added to favorites.</string>
+    <string name="favorite_categories_add_finished">Category successfully added to favorites.</string>
     <string name="favorite_remove_finished">The book successfully removed from favorites.</string>
+    <string name="favorite_categories_remove_finished">The book successfully removed from favorites.</string>
     <string name="action_share">Share....</string>
 	<string name="action_share_send_text">I found a interesting book:\"%1$s\" Link:%2$s (R-18 WARNING! Share from NHBooks Client https://github.com/fython/NHentai-android )</string>
 	<string name="action_share_send_category">%1$s is great. Link:%2$s (R-18 WARNING! Share from NHBooks Client https://github.com/fython/NHentai-android )</string>


### PR DESCRIPTION
Overall: Array was checked in a wrong position all the time (Fixes some devices doing FC´s)

Page List Fragment -> Check Position 0 of Array (Fixes FC´s)

Category Activity -> Updated Strings

Home Activity -> Check Position 0 of Array (Fixes FC´s)

Search Activity -> Check Position 0 of Array (Fixes FC´s)