### PR TITLE
Hotfix Clean Categories

### DIFF
--- a/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
+++ b/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
@@ -479,6 +479,25 @@ public class FileCacheManager {
 		return updateFile.exists();
 	}
 
+	public boolean checkUpdateCategories(){
+		File updateFile = new File(mCacheDir.getAbsolutePath()+ "/Books/updateCat.txt");
+		return updateFile.exists();
+	}
+
+	public boolean UpdateFavoriteCategories(){
+		File updateFile = new File(mCacheDir.getAbsolutePath()+ "/Books/updateCat.txt");
+		try {
+			OutputStream out = new FileOutputStream(updateFile);
+			out.write(String.valueOf("updated").getBytes());
+			out.close();
+			Log.d(TAG, "Categories Updated Wroted");
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+		return true;
+	}
+
 	public boolean UpdateFavorites(){
 		File updateFile = new File(mCacheDir.getAbsolutePath()+ "/Books/updateFab.txt");
 		try {

--- a/app/src/main/java/moe/feng/nhentai/dao/FavoriteCategoriesManager.java
+++ b/app/src/main/java/moe/feng/nhentai/dao/FavoriteCategoriesManager.java
@@ -1,13 +1,17 @@
 package moe.feng.nhentai.dao;
 
 import android.content.Context;
+import android.util.Log;
 
 import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
+import moe.feng.nhentai.cache.file.FileCacheManager;
+import moe.feng.nhentai.model.BaseMessage;
 import moe.feng.nhentai.model.Category;
+import moe.feng.nhentai.util.AsyncTask;
 import moe.feng.nhentai.util.Utility;
 
 public class FavoriteCategoriesManager {
@@ -44,6 +48,10 @@ public class FavoriteCategoriesManager {
 		}
 
 		categories = new Gson().fromJson(json, MyArray.class);
+		if (!FileCacheManager.getInstance(context).checkUpdateCategories()){
+			new UpdateCategories().execute(context);
+			save();
+		}
 	}
 
 	public Category get(int position) {
@@ -130,6 +138,24 @@ public class FavoriteCategoriesManager {
 		public void remove(int position) {
 			data.remove(position);
 		}
+
+	}
+
+	private class UpdateCategories extends AsyncTask<Context, Void, BaseMessage> {
+		@Override
+		protected BaseMessage doInBackground(Context... params) {
+			categories.data = new ArrayList<>();
+			FileCacheManager.getInstance(params[0]).UpdateFavoriteCategories();
+
+			return null;
+		}
+
+
+		@Override
+		protected void onPostExecute(BaseMessage msg) {
+			Log.d(TAG, "Favorites Update Complete ");
+		}
+
 
 	}
 

--- a/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
@@ -59,6 +59,7 @@ import io.codetail.widget.RevealFrameLayout;
 import moe.feng.nhentai.R;
 import moe.feng.nhentai.api.PageApi;
 import moe.feng.nhentai.cache.file.FileCacheManager;
+import moe.feng.nhentai.dao.FavoriteCategoriesManager;
 import moe.feng.nhentai.dao.FavoritesManager;
 import moe.feng.nhentai.dao.LatestBooksKeeper;
 import moe.feng.nhentai.model.BaseMessage;
@@ -198,7 +199,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 			new UpdateData().execute(1);
 		}
 
-		if (mListKeeper.getData() != null && !mListKeeper.getData().isEmpty() && mListKeeper.getUpdatedMiles() != -1) {
+		if (mListKeeper.getData() != null && !mListKeeper.getData().isEmpty() && mListKeeper.getUpdatedMiles() != -1 && mFileCacheManager.checkUpdateLatest()) {
 			mBooks = mListKeeper.getData();
 			mNowPage = mListKeeper.getNowPage();
 			mAdapter = new BookListRecyclerAdapter(mRecyclerView, mBooks, mFM, mSets);
@@ -210,7 +211,6 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 			setRecyclerAdapter(mAdapter);
 			new PageGetTask().execute(mNowPage);
 		}
-
 	}
 
 	private void onLoadMain() {
@@ -321,7 +321,6 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 	@Override
 	protected void onStop() {
 		super.onStop();
-		mFM.save();
 	}
 
 	@Override
@@ -796,6 +795,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 		@Override
 		protected BaseMessage doInBackground(Integer... params) {
 			mFileCacheManager.updateSaved(getApplicationContext());
+
 			return null;
 		}
 
@@ -811,6 +811,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 		@Override
 		protected BaseMessage doInBackground(Integer... params) {
 			mFM.reload(getApplicationContext());
+			FavoriteCategoriesManager.getInstance(getApplicationContext()).reload();
 			return PageApi.getHomePageList(params[0]);
 		}
 


### PR DESCRIPTION
Overall: When Upgrading we clear the saved categories

Favorite Categories Manager -> the new API forces us to change how the categories are searched. Therefore we have to erase the old ones.

Home Activity -> Erase old categories

File Cache Manager -> Add functions to properly update categories