### PR TITLE
Performance Update: Network Reduction, Better Image Handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
 		applicationId "moe.feng.nhentai"
 		minSdkVersion 17
 		targetSdkVersion 24
-		versionCode 26
-		versionName "1.5.1"
+		versionCode 27
+		versionName "1.6.0"
 	}
 
 	buildTypes {
@@ -30,7 +30,6 @@ dependencies {
 	compile 'com.google.code.gson:gson:2.4'
 	compile 'org.jsoup:jsoup:1.8.2'
 	compile 'com.github.chrisbanes.photoview:library:1.2.3'
-	compile 'com.squareup.picasso:picasso:2.5.2'
 	compile 'com.lid.labelview:lib:0.1.1'
 	compile 'com.github.ksoichiro:android-observablescrollview:1.6.0'
 	compile 'com.nineoldandroids:library:2.4.0'

--- a/app/src/main/java/moe/feng/nhentai/api/BookApi.java
+++ b/app/src/main/java/moe/feng/nhentai/api/BookApi.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
 
-import java.io.File;
-
 import moe.feng.nhentai.api.common.NHentaiUrl;
 import moe.feng.nhentai.cache.file.FileCacheManager;
 import moe.feng.nhentai.model.BaseMessage;
@@ -41,38 +39,54 @@ public class BookApi {
 
 	public static Bitmap getCover(Context context, Book book) {
 		String url = book.bigCoverImageUrl;
-		FileCacheManager m = FileCacheManager.getInstance(context);
-		
-		if (!m.cacheExistsUrl(CACHE_COVER, url, book.title) && !m.createCacheFromNetwork(CACHE_COVER, url, book.title)) {
+
+		if (FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_COVER, url, book.title)){
+			Log.d(TAG, "Cover: Loaded from cache");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_COVER, url, book.title);
+		}
+		else if (FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_COVER, url, book.title)){
+			Log.d(TAG, "Cover: Downloaded from web");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_COVER, url, book.title);
+		}
+		else {
 			return null;
 		}
 
-		return m.getBitmapUrl(CACHE_COVER, url, book.title);
 	}
 
 	public static Bitmap getThumb(Context context, Book book) {
 		String url = book.previewImageUrl;
-		FileCacheManager m = FileCacheManager.getInstance(context);
 
-		if (!m.cacheExistsUrl(CACHE_THUMB, url, book.title) && !m.createCacheFromNetwork(CACHE_THUMB, url, book.title)) {
+		if (FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_THUMB, url, book.title)){
+			Log.d(TAG, "Thumb: Loaded from cache");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_THUMB, url, book.title);
+		}
+		else if (FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_THUMB, url, book.title)){
+			Log.d(TAG, "Thumb: Downloaded from web");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_THUMB, url, book.title);
+		}
+		else {
 			return null;
 		}
 
-		return m.getBitmapUrl(CACHE_THUMB, url, book.title);
 	}
 
 	public static Bitmap getPageThumb(Context context, Book book, int position) {
 		String url = NHentaiUrl.getThumbPictureUrl(book.galleryId, Integer.toString(position));
-		FileCacheManager m = FileCacheManager.getInstance(context);
-
-		if (!m.cacheExistsUrl(CACHE_PAGE_THUMB, url, book.title) && !m.createCacheFromNetwork(CACHE_PAGE_THUMB, url, book.title)) {
+		if (FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_THUMB, url, book.title)){
+			Log.d(TAG, "Page Thumb: Loaded from cache");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_THUMB, url, book.title);
+		}
+		else if (FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_THUMB, url, book.title)){
+			Log.d(TAG, "Page Thumb: Downloaded from web");
+			return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_THUMB, url, book.title);
+		}
+		else {
 			return null;
 		}
-
-		return m.getBitmapUrl(CACHE_PAGE_THUMB, url, book.title);
 	}
 
-	public static File getCoverFile(Context context, Book book) {
+	/*public static File getCoverFile(Context context, Book book) {
 		String url = book.bigCoverImageUrl;
 		FileCacheManager m = FileCacheManager.getInstance(context);
 
@@ -103,6 +117,6 @@ public class BookApi {
 		}
 
 		return m.getBitmapUrlFile(CACHE_PAGE_THUMB, url,book.title);
-	}
+	}*/
 
 }

--- a/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
+++ b/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
@@ -36,8 +36,6 @@ public class FileCacheManager {
 
 	private File mCacheDir, mExternalDir;
 
-	private Bitmap ret;
-
 	private FileCacheManager(Context context) {
 		try {
 			mCacheDir = context.getExternalCacheDir();
@@ -266,7 +264,7 @@ public class FileCacheManager {
 	}
 
 	public Bitmap getBitmapFile(File f) {
-		ret=null;
+		Bitmap result;
 		FileInputStream ipt= null;
 
 		try {
@@ -291,7 +289,7 @@ public class FileCacheManager {
 		}
 
 		bounds.inJustDecodeBounds=false;
-		ret=BitmapFactory.decodeStream(iptF,null, bounds);
+		result=BitmapFactory.decodeStream(iptF,null, bounds);
 
 		try {
 			ipt.close();
@@ -305,12 +303,12 @@ public class FileCacheManager {
 
 		}
 
-		return ret;
+		return result;
 	}
 
 
 	public Bitmap getBitmap(String type, String name, String title) {
-		ret=null;
+		Bitmap result;
 
 		FileInputStream ipt= openCacheStream(type, name, title);
 		if (ipt == null) return null;
@@ -324,7 +322,7 @@ public class FileCacheManager {
 		FileInputStream iptF=openCacheStream(type,name, title);
 
 		bounds.inJustDecodeBounds=false;
-		ret=BitmapFactory.decodeStream(iptF,null, bounds);
+		result=BitmapFactory.decodeStream(iptF,null, bounds);
 
 		try {
 			ipt.close();
@@ -338,7 +336,7 @@ public class FileCacheManager {
 
 		}
 
-		return ret;
+		return result;
 	}
 
 

--- a/app/src/main/java/moe/feng/nhentai/dao/FavoriteCategoriesManager.java
+++ b/app/src/main/java/moe/feng/nhentai/dao/FavoriteCategoriesManager.java
@@ -50,6 +50,8 @@ public class FavoriteCategoriesManager {
 		categories = new Gson().fromJson(json, MyArray.class);
 		if (!FileCacheManager.getInstance(context).checkUpdateCategories()){
 			new UpdateCategories().execute(context);
+		}
+		else {
 			save();
 		}
 	}
@@ -154,6 +156,7 @@ public class FavoriteCategoriesManager {
 		@Override
 		protected void onPostExecute(BaseMessage msg) {
 			Log.d(TAG, "Favorites Update Complete ");
+			save();
 		}
 
 

--- a/app/src/main/java/moe/feng/nhentai/dao/FavoritesManager.java
+++ b/app/src/main/java/moe/feng/nhentai/dao/FavoritesManager.java
@@ -50,6 +50,8 @@ public class FavoritesManager {
 		books = new Gson().fromJson(json, MyArray.class);
 		if (!FileCacheManager.getInstance(context).checkUpdateFavorites()){
 			new UpdateFavorites().execute(context);
+		}
+		else{
 			save();
 		}
 	}
@@ -173,6 +175,7 @@ public class FavoritesManager {
 		@Override
 		protected void onPostExecute(BaseMessage msg) {
 			Log.d(TAG, "Favorites Update Complete ");
+			save();
 		}
 
 

--- a/app/src/main/java/moe/feng/nhentai/ui/GalleryActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/GalleryActivity.java
@@ -130,14 +130,13 @@ public class GalleryActivity extends AbsActivity implements OnTouchListener {
 	@Override
 	public void onPause() {
 		super.onPause();
-
+		mDownloader.pause();
 	}
 
 	@Override
 	public void onStop() {
 		super.onStop();
 		mDownloader.stop();
-		Runtime.getRuntime().gc();
 	}
 
 	@Override
@@ -309,6 +308,10 @@ public class GalleryActivity extends AbsActivity implements OnTouchListener {
 		if (mAppBar.getAlpha() != 1f) {
 			toggleControlBar();
 		} else {
+			book =null;
+			mPagerAdpater.notifyDataSetChanged();
+			mPager.setAdapter(null);
+			Runtime.getRuntime().gc();
 			super.onBackPressed();
 		}
 	}

--- a/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
@@ -324,6 +324,12 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 	}
 
 	@Override
+	protected void onResume(){
+		super.onResume();
+		Runtime.getRuntime().gc();
+	}
+
+	@Override
 	protected void onPostCreate(Bundle savedInstanceState) {
 		super.onPostCreate(savedInstanceState);
 		mDrawerToggle.syncState();

--- a/app/src/main/java/moe/feng/nhentai/ui/RandomActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/RandomActivity.java
@@ -72,6 +72,15 @@ public class RandomActivity extends AbsActivity {
 	}
 
 	@Override
+	public void onBackPressed(){
+		super.onBackPressed();
+		mCoverView.setImageBitmap(null);
+		mCoverView.invalidate();
+
+		mLangFieldView.setImageBitmap(null);
+		mLangFieldView.invalidate();
+	}
+	@Override
 	protected void setUpViews() {
 		mFAB = $(R.id.fab);
 		mCoverView = $(R.id.iv_cover);

--- a/app/src/main/java/moe/feng/nhentai/ui/SearchActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/SearchActivity.java
@@ -99,6 +99,15 @@ public class SearchActivity extends AbsActivity {
 	}
 
 	@Override
+	public void onBackPressed(){
+		super.onBackPressed();
+		mBooks =null;
+		mAdapter.notifyDataSetChanged();
+		mResultList.setAdapter(null);
+		Runtime.getRuntime().gc();
+	}
+
+	@Override
 	protected void setUpViews() {
 		mTopBar = $(R.id.top_card_layout);
 		mEditText = new AppCompatEditText(this);

--- a/app/src/main/java/moe/feng/nhentai/ui/adapter/BookGridRecyclerAdapter.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/adapter/BookGridRecyclerAdapter.java
@@ -1,5 +1,7 @@
 package moe.feng.nhentai.ui.adapter;
 
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
@@ -11,12 +13,7 @@ import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.github.florent37.materialimageloading.MaterialImageLoading;
 import com.lid.lib.LabelView;
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
-
-import java.io.File;
 import java.util.ArrayList;
 
 import moe.feng.nhentai.R;
@@ -35,7 +32,6 @@ public class BookGridRecyclerAdapter extends AbsRecyclerViewAdapter {
 	private ArrayList<Book> data;
 	private FavoritesManager fm;
 	private Settings sets;
-
 	private ColorGenerator mColorGenerator;
 
 	public static final String TAG = BookGridRecyclerAdapter.class.getSimpleName();
@@ -56,6 +52,11 @@ public class BookGridRecyclerAdapter extends AbsRecyclerViewAdapter {
 	public void onViewRecycled(ClickableViewHolder holder) {
 		super.onViewRecycled(holder);
 		((ViewHolder) holder).labelView.remove();
+		((ViewHolder) holder).mPreviewImageView.setImageBitmap(null);
+		((ViewHolder) holder).mPreviewImageView.invalidate();
+
+		((ViewHolder) holder).mLangFieldView.setImageBitmap(null);
+		((ViewHolder) holder).mLangFieldView.invalidate();
 	}
 
 	@Override
@@ -141,13 +142,13 @@ public class BookGridRecyclerAdapter extends AbsRecyclerViewAdapter {
 			Book book = h.book;
 
 			if (v != null && !TextUtils.isEmpty(book.previewImageUrl)) {
-				ImageView imgView = h.mPreviewImageView;
-
+				ImageView imageView = h.mPreviewImageView;
 				boolean useHdImage = sets != null && sets.getBoolean(Settings.KEY_LIST_HD_IMAGE, false);
-				File img = useHdImage ? BookApi.getCoverFile(getContext(), book) : BookApi.getThumbFile(getContext(), book);
+				Bitmap img = useHdImage ? BookApi.getCover(getContext(), book) : BookApi.getThumb
+						(getContext(), book);
 
 				if (img != null) {
-					publishProgress(new Object[]{v, img, imgView, book});
+					publishProgress(new Object[]{v, img, imageView, book});
 				}
 			}
 
@@ -161,29 +162,15 @@ public class BookGridRecyclerAdapter extends AbsRecyclerViewAdapter {
 			View v = (View) values[0];
 
 			if (!(v.getTag() instanceof ViewHolder) || (((ViewHolder) v.getTag()).book != null &&
-					((ViewHolder) v.getTag()).book.bookId != ((Book) values[3]).bookId)) {
+					!((ViewHolder) v.getTag()).book.bookId.equals(((Book) values[3]).bookId))) {
 				return;
 			}
-
-			File img = (File) values[1];
-			final ImageView iv = (ImageView) values[2];
-			iv.setVisibility(View.VISIBLE);
-			iv.setTag(false);
-
-			Picasso.with(getContext())
-					.load(img)
-					.placeholder(((ViewHolder) v.getTag()).mImagePlaceholder)
-					.into(iv, new Callback() {
-						@Override
-						public void onSuccess() {
-                            MaterialImageLoading.animate(iv).setDuration(1500).start();
-						}
-
-						@Override
-						public void onError() {
-
-						}
-					});
+			Bitmap img = (Bitmap) values[1];
+			ImageView imageView = (ImageView) values [2];
+			imageView.setVisibility(View.VISIBLE);
+			imageView.setTag(false);
+			imageView.setImageBitmap(img);
+			imageView.invalidate();
 		}
 
 

--- a/app/src/main/java/moe/feng/nhentai/ui/adapter/BookListRecyclerAdapter.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/adapter/BookListRecyclerAdapter.java
@@ -1,10 +1,9 @@
 package moe.feng.nhentai.ui.adapter;
 
+import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.support.v7.widget.RecyclerView;
-import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
-import android.text.style.ImageSpan;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,12 +12,7 @@ import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.github.florent37.materialimageloading.MaterialImageLoading;
 import com.lid.lib.LabelView;
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
-
-import java.io.File;
 import java.util.ArrayList;
 
 import moe.feng.nhentai.R;
@@ -37,7 +31,6 @@ public class BookListRecyclerAdapter extends AbsRecyclerViewAdapter {
 	private ArrayList<Book> data;
 	private FavoritesManager fm;
 	private Settings sets;
-
 	private ColorGenerator mColorGenerator;
 
 	public static final String TAG = BookListRecyclerAdapter.class.getSimpleName();
@@ -58,6 +51,11 @@ public class BookListRecyclerAdapter extends AbsRecyclerViewAdapter {
 	public void onViewRecycled(ClickableViewHolder holder) {
 		super.onViewRecycled(holder);
 		((ViewHolder) holder).labelView.remove();
+		((ViewHolder) holder).mPreviewImageView.setImageBitmap(null);
+		((ViewHolder) holder).mPreviewImageView.invalidate();
+
+		((ViewHolder) holder).mLangFieldView.setImageBitmap(null);
+		((ViewHolder) holder).mLangFieldView.invalidate();
 	}
 
 	@Override
@@ -89,8 +87,8 @@ public class BookListRecyclerAdapter extends AbsRecyclerViewAdapter {
                     break;
             }
 
-			int color = mColorGenerator.getColor(data.get(position).getAvailableTitle());
-			TextDrawable drawable = TextDrawable.builder().buildRect(Utility.getFirstCharacter(data.get(position).getAvailableTitle()), color);
+			int color = mColorGenerator.getColor(data.get(position).getAvailableTitle() !=null ? data.get(position).getAvailableTitle() : "Doujin");
+			TextDrawable drawable = TextDrawable.builder().buildRect(Utility.getFirstCharacter(data.get(position).getAvailableTitle() != null? data.get(position).getAvailableTitle(): "Doujin"), color);
 			mHolder.mPreviewImageView.setImageDrawable(drawable);
 			mHolder.mImagePlaceholder = drawable;
 
@@ -143,13 +141,12 @@ public class BookListRecyclerAdapter extends AbsRecyclerViewAdapter {
 			Book book = h.book;
 
 			if (v != null && !TextUtils.isEmpty(book.previewImageUrl)) {
-				ImageView imgView = h.mPreviewImageView;
-
+				ImageView imageView = h.mPreviewImageView;
 				boolean useHdImage = sets != null && sets.getBoolean(Settings.KEY_LIST_HD_IMAGE, false);
-				File img = useHdImage ? BookApi.getCoverFile(getContext(), book) : BookApi.getThumbFile(getContext(), book);
+				Bitmap img = useHdImage ? BookApi.getCover(getContext(), book) : BookApi.getThumb(getContext(), book);
 
 				if (img != null) {
-					publishProgress(new Object[]{v, img, imgView, book});
+					publishProgress(new Object[]{v, img, imageView, book});
 				}
 			}
 
@@ -161,31 +158,17 @@ public class BookListRecyclerAdapter extends AbsRecyclerViewAdapter {
 			super.onProgressUpdate(values);
 
 			View v = (View) values[0];
-
+			Bitmap img = (Bitmap) values[1];
+			ImageView imageView = (ImageView) values [2];
 			if (!(v.getTag() instanceof ViewHolder) || (((ViewHolder) v.getTag()).book != null &&
-					((ViewHolder) v.getTag()).book.bookId != ((Book) values[3]).bookId)) {
+					!((ViewHolder) v.getTag()).book.bookId.equals(((Book) values[3]).bookId))) {
 				return;
 			}
 
-			File img = (File) values[1];
-			final ImageView iv = (ImageView) values[2];
-			iv.setVisibility(View.VISIBLE);
-			iv.setTag(false);
-
-			Picasso.with(getContext())
-					.load(img)
-					.placeholder(((ViewHolder) v.getTag()).mImagePlaceholder)
-					.into(iv, new Callback() {
-						@Override
-						public void onSuccess() {
-                            MaterialImageLoading.animate(iv).setDuration(1500).start();
-						}
-
-						@Override
-						public void onError() {
-
-						}
-					});
+			imageView.setVisibility(View.VISIBLE);
+			imageView.setTag(false);
+			imageView.setImageBitmap(img);
+			imageView.invalidate();
 		}
 
 

--- a/app/src/main/java/moe/feng/nhentai/ui/adapter/BookPreviewGridAdapter.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/adapter/BookPreviewGridAdapter.java
@@ -1,17 +1,13 @@
 package moe.feng.nhentai.ui.adapter;
 
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
-
-import java.io.File;
 
 import moe.feng.nhentai.R;
 import moe.feng.nhentai.api.BookApi;
@@ -22,11 +18,19 @@ import moe.feng.nhentai.util.AsyncTask;
 public class BookPreviewGridAdapter extends AbsRecyclerViewAdapter {
 
 	private Book book;
-
 	public BookPreviewGridAdapter(RecyclerView rv, Book book) {
 		super(rv);
 		this.book = book;
 	}
+	@Override
+	public void onViewRecycled(ClickableViewHolder holder) {
+		super.onViewRecycled(holder);
+
+		((ViewHolder) holder).mBookImageView.setImageBitmap(null);
+		((ViewHolder) holder).mBookImageView.invalidate();
+	}
+
+
 
 	@Override
 	public ClickableViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -44,7 +48,7 @@ public class BookPreviewGridAdapter extends AbsRecyclerViewAdapter {
 		if (cvh instanceof ViewHolder) {
 			ViewHolder holder = (ViewHolder) cvh;
 
-			holder.mImageView.setVisibility(View.INVISIBLE);
+			holder.mBookImageView.setVisibility(View.INVISIBLE);
 			holder.mNumberText.setText(Integer.toString(position + 1));
 
 			new ImageDownloader().execute(holder.getParentView(), position + 1);
@@ -58,12 +62,12 @@ public class BookPreviewGridAdapter extends AbsRecyclerViewAdapter {
 
 	public class ViewHolder extends AbsRecyclerViewAdapter.ClickableViewHolder {
 
-		ImageView mImageView;
+		ImageView mBookImageView;
 		TextView mNumberText;
 
 		public ViewHolder(View itemView) {
 			super(itemView);
-			this.mImageView = (ImageView) itemView.findViewById(R.id.image_view);
+			this.mBookImageView = (ImageView) itemView.findViewById(R.id.image_view);
 			this.mNumberText = (TextView) itemView.findViewById(R.id.number_text);
 
 			itemView.setTag(this);
@@ -79,12 +83,12 @@ public class BookPreviewGridAdapter extends AbsRecyclerViewAdapter {
 			ViewHolder h = (ViewHolder) v.getTag();
 
 			if (v != null) {
-				ImageView imgView = h.mImageView;
-
-				File img = BookApi.getPageThumbFile(getContext(), book, (int) params[1]);
+				ImageView imageView = h.mBookImageView;
+				Bitmap img = BookApi.getPageThumb(getContext(), book, (int) params[1]);
 
 				if (img != null) {
-					publishProgress(new Object[]{v, img, imgView, book, params[1]});
+					publishProgress(new Object[]{v, img, imageView, book, params[1]});
+
 				}
 			}
 
@@ -107,23 +111,12 @@ public class BookPreviewGridAdapter extends AbsRecyclerViewAdapter {
 				return;
 			}
 
-			File img = (File) values[1];
-			final ImageView iv = (ImageView) values[2];
-			iv.setVisibility(View.VISIBLE);
-			iv.setTag(false);
-
-			Picasso.with(getContext())
-					.load(img)
-					.into(iv, new Callback() {
-						@Override
-						public void onSuccess() {
-						}
-
-						@Override
-						public void onError() {
-
-						}
-					});
+			Bitmap img = (Bitmap) values[1];
+			ImageView imageView = (ImageView) values [2];
+			imageView.setVisibility(View.VISIBLE);
+			imageView.setTag(false);
+			imageView.setImageBitmap(img);
+			imageView.invalidate();
 		}
 
 

--- a/app/src/main/java/moe/feng/nhentai/ui/fragment/main/DownloadManagerFragment.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/fragment/main/DownloadManagerFragment.java
@@ -76,8 +76,8 @@ public class DownloadManagerFragment extends LazyFragment {
 	}
 
 	private void setRecyclerViewAdapter(BookListRecyclerAdapter adapter) {
-		mRecyclerView.setAdapter(mAdapter);
-		mAdapter.setOnItemClickListener(new AbsRecyclerViewAdapter.OnItemClickListener() {
+
+		adapter.setOnItemClickListener(new AbsRecyclerViewAdapter.OnItemClickListener() {
 			@Override
 			public void onItemClick(int position, AbsRecyclerViewAdapter.ClickableViewHolder viewHolder) {
 				BookListRecyclerAdapter.ViewHolder holder = (BookListRecyclerAdapter.ViewHolder) viewHolder;
@@ -86,6 +86,8 @@ public class DownloadManagerFragment extends LazyFragment {
 				BookDetailsActivity.launch(getActivity(), holder.mPreviewImageView, holder.book, position);
 			}
 		});
+		mRecyclerView.setAdapter(adapter);
+		adapter.notifyDataSetChanged();
 	}
 
 	public void scrollToTop() {
@@ -98,7 +100,6 @@ public class DownloadManagerFragment extends LazyFragment {
 
 		@Override
 		protected ArrayList<Book> doInBackground(Void... params) {
-			getFavoritesManager().reload(getApplicationContext());
 			return FileCacheManager.getInstance(getApplicationContext()).getExternalBooks();
 		}
 
@@ -113,11 +114,9 @@ public class DownloadManagerFragment extends LazyFragment {
 	}
 
 	private FavoritesManager getFavoritesManager() {
-		if (getActivity() != null && getActivity() instanceof HomeActivity) {
-			return ((HomeActivity) getActivity()).getFavoritesManager();
-		} else {
 			return FavoritesManager.getInstance(getApplicationContext());
-		}
 	}
+
+
 
 }

--- a/app/src/main/java/moe/feng/nhentai/ui/fragment/main/FavoriteFragment.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/fragment/main/FavoriteFragment.java
@@ -58,17 +58,19 @@ public class FavoriteFragment extends LazyFragment {
 				new FavoritesRefreshTask().execute();
 			}
 		});
+		new FavoritesRefreshTask().execute();
 	}
 
 	private void setRecyclerViewAdapter(BookListRecyclerAdapter adapter) {
-		mRecyclerView.setAdapter(mAdapter);
-		mAdapter.setOnItemClickListener(new AbsRecyclerViewAdapter.OnItemClickListener() {
+		adapter.setOnItemClickListener(new AbsRecyclerViewAdapter.OnItemClickListener() {
 			@Override
 			public void onItemClick(int position, AbsRecyclerViewAdapter.ClickableViewHolder viewHolder) {
 				BookListRecyclerAdapter.ViewHolder holder = (BookListRecyclerAdapter.ViewHolder) viewHolder;
 				BookDetailsActivity.launch(getActivity(), holder.mPreviewImageView, holder.book, position);
 			}
 		});
+		mRecyclerView.setAdapter(adapter);
+		adapter.notifyDataSetChanged();
 	}
 
 	public void scrollToTop() {
@@ -87,18 +89,14 @@ public class FavoriteFragment extends LazyFragment {
 
 		@Override
 		protected void onPostExecute(Void result) {
-			mSwipeRefreshLayout.setRefreshing(false);
 			mAdapter.notifyDataSetChanged();
+			mSwipeRefreshLayout.setRefreshing(false);
 		}
 
 	}
 
 	private FavoritesManager getFavoritesManager() {
-		if (getActivity() != null && getActivity() instanceof HomeActivity) {
-			return ((HomeActivity) getActivity()).getFavoritesManager();
-		} else {
 			return FavoritesManager.getInstance(getApplicationContext());
-		}
 	}
 
 }

--- a/app/src/main/res/layout/activity_random.xml
+++ b/app/src/main/res/layout/activity_random.xml
@@ -59,16 +59,16 @@
 	    </FrameLayout>
 
         <FrameLayout
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="start"
+            android:layout_gravity="center_horizontal"
             android:layout_marginBottom="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp">
+			android:layout_marginLeft="16dp"
+			android:layout_marginRight="16dp">
 
             <ImageView
-                android:layout_width="20sp"
-                android:layout_height="20sp"
+                android:layout_width="30sp"
+                android:layout_height="30sp"
                 android:translationY="1sp"
                 android:id="@+id/book_lang_field"
                 android:layout_gravity="start"
@@ -81,6 +81,8 @@
                 android:id="@+id/book_title"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 android:textColor="@android:color/primary_text_dark"
+				android:gravity="center"
+				android:layout_marginLeft="16dp"
                 android:alpha="0.9"
                 tools:text="     Title"/>
 


### PR DESCRIPTION
Overall: Reduced Netowrk Usage when getting preview thumbs, Better Memory Handling, Fixes for duplicate images, Bug Fixes,

BookApi -> Fixed logic to only create cache of thumbs when its not present (Old way checked and redownloaded images at the same time)

File Cache Manager -> Don´t reuse bitmap (Fixes duplicate of images)

Favorite Categories Manager -> Small Cleanups and fixes

Favorites Manager -> Small Cleanups and fixes

Book Grid Recycler Adapter -> Using manual loading instead of Picasso

Book List Recycler Adapter -> Using manual loading instead of Picasso

Book Preview Grid Adapter -> Using manual loading instead of Picasso

Download Manager Fragment -> Small Cleanups and fixes

Favorite Fragment -> Small Cleanups and fixes

Book Page Fragment -> Small Cleanups and fixes

Book Details Activity -> Fixed memory leak
Book Details Activity -> Small Cleanups and fixes

Gallery Activity -> Fixed memory leak
Gallery Activity -> Small Cleanups and fixes

Home Activity -> Small Cleanups and fixes

Random Activity -> Fixed memory leak
Random Activity -> Small Cleanups and fixes

Search Activity -> Fixed memory leak
Search Activity -> Small Cleanups and fixes

Layout Activity Random -> Small adjustments

Build Gradle -> No more picasso needed
Build Gradle -> Bump to version 1.6.0 (27)