### PR TITLE
Hotfix Check Nulls in Favorites

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
 		applicationId "moe.feng.nhentai"
 		minSdkVersion 17
 		targetSdkVersion 24
-		versionCode 28
-		versionName "1.6.1"
+		versionCode 29
+		versionName "1.6.2"
 	}
 
 	buildTypes {

--- a/app/src/main/java/moe/feng/nhentai/dao/FavoritesManager.java
+++ b/app/src/main/java/moe/feng/nhentai/dao/FavoritesManager.java
@@ -48,6 +48,16 @@ public class FavoritesManager {
 		}
 
 		books = new Gson().fromJson(json, MyArray.class);
+
+		ArrayList<Book> toRemove = new ArrayList<>();
+		for (Book book : books.data){
+			if (book.bookId == null){
+				toRemove.add(book);
+			}
+		}
+		books.data.removeAll(toRemove);
+
+
 		if (!FileCacheManager.getInstance(context).checkUpdateFavorites()){
 			new UpdateFavorites().execute(context);
 		}
@@ -55,8 +65,6 @@ public class FavoritesManager {
 			save();
 		}
 	}
-
-
 
 	public Book get(int position) {
 		return books.get(position);


### PR DESCRIPTION
Overall: If by any chance one books get added with nulls in it, we now properly mantain the list now

Favorites Manager -> Fixed  null books on favorites (Could be caused by a lot of stuff)

Build Gradle -> Bump to version 1.6.2 (29)