### PR TITLE
Added setting for calculateInSampleSize

### DIFF
--- a/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
+++ b/app/src/main/java/moe/feng/nhentai/cache/file/FileCacheManager.java
@@ -28,6 +28,7 @@ import moe.feng.nhentai.api.common.NHentaiUrl;
 import moe.feng.nhentai.cache.common.Constants;
 import moe.feng.nhentai.model.Book;
 import moe.feng.nhentai.ui.HomeActivity;
+import moe.feng.nhentai.util.Settings;
 
 import static moe.feng.nhentai.BuildConfig.DEBUG;
 
@@ -39,7 +40,11 @@ public class FileCacheManager {
 
 	private File mCacheDir, mExternalDir;
 
+	private Settings mSettings;
+
 	private FileCacheManager(Context context) {
+		mSettings = Settings.getInstance(context);
+
 		try {
 			mCacheDir = context.getExternalCacheDir();
 		} catch (Exception e) {
@@ -281,7 +286,9 @@ public class FileCacheManager {
 		bounds.inJustDecodeBounds=true;
 		BitmapFactory.decodeStream(ipt,null,bounds);
 
-		bounds.inSampleSize = calculateInSampleSize(bounds,720, 1280);
+		if (mSettings.getBoolean(Settings.KEY_GALLERY_COMPRESSION, false)) {
+			bounds.inSampleSize = calculateInSampleSize(bounds, 720, 1280);
+		}
 
 		Log.d(TAG, "getBitmap: " + bounds.inSampleSize);
 		FileInputStream iptF;
@@ -318,7 +325,9 @@ public class FileCacheManager {
 		bounds.inJustDecodeBounds=true;
 		BitmapFactory.decodeStream(ipt,null,bounds);
 
-		bounds.inSampleSize = calculateInSampleSize(bounds,480, 640);
+		if (mSettings.getBoolean(Settings.KEY_GALLERY_COMPRESSION, false)) {
+			bounds.inSampleSize = calculateInSampleSize(bounds, 480, 640);
+		}
 
 		FileInputStream iptF=openCacheStream(type,name, title);
 

--- a/app/src/main/java/moe/feng/nhentai/ui/fragment/settings/SettingsAppearance.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/fragment/settings/SettingsAppearance.java
@@ -20,7 +20,7 @@ import moe.feng.nhentai.view.pref.SwitchPreference;
 public class SettingsAppearance extends PreferenceFragment implements Preference.OnPreferenceClickListener, android.preference.Preference.OnPreferenceChangeListener {
 
 	private Preference mCardCountPref;
-	private SwitchPreference mHDImagePref, mFullHDPreviewPref, mAllowStandaloneTaskPref;
+	private SwitchPreference mHDImagePref, mFullHDPreviewPref, mAllowStandaloneTaskPref, mGalleryCompressionPref;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -33,6 +33,7 @@ public class SettingsAppearance extends PreferenceFragment implements Preference
 		mHDImagePref = (SwitchPreference) findPreference("hd_image");
 		mFullHDPreviewPref = (SwitchPreference) findPreference("full_image_preview");
 		mAllowStandaloneTaskPref = (SwitchPreference) findPreference("allow_standalone_task");
+		mGalleryCompressionPref = (SwitchPreference) findPreference("gallery_image_compression");
 
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
 			mAllowStandaloneTaskPref.setEnabled(false);
@@ -51,11 +52,13 @@ public class SettingsAppearance extends PreferenceFragment implements Preference
 		mHDImagePref.setChecked(mSets.getBoolean(Settings.KEY_LIST_HD_IMAGE, false));
 		mFullHDPreviewPref.setChecked(mSets.getBoolean(Settings.KEY_FULL_IMAGE_PREVIEW, false));
 		mAllowStandaloneTaskPref.setChecked(mSets.getBoolean(Settings.KEY_ALLOW_STANDALONE_TASK, true) && mAllowStandaloneTaskPref.isEnabled());
+		mGalleryCompressionPref.setChecked(mSets.getBoolean(Settings.KEY_GALLERY_COMPRESSION, false) && mGalleryCompressionPref.isEnabled());
 
 		mCardCountPref.setOnPreferenceClickListener(this);
 		mHDImagePref.setOnPreferenceChangeListener(this);
 		mFullHDPreviewPref.setOnPreferenceChangeListener(this);
 		mAllowStandaloneTaskPref.setOnPreferenceChangeListener(this);
+		mGalleryCompressionPref.setOnPreferenceChangeListener(this);
 	}
 
 	@Override
@@ -165,6 +168,12 @@ public class SettingsAppearance extends PreferenceFragment implements Preference
 			Boolean b = (Boolean) o;
 			mSets.putBoolean(Settings.KEY_ALLOW_STANDALONE_TASK, b);
 			mAllowStandaloneTaskPref.setChecked(b);
+			return true;
+		}
+		if (pref == mGalleryCompressionPref) {
+			Boolean b = (Boolean) o;
+			mSets.putBoolean(Settings.KEY_GALLERY_COMPRESSION, b);
+			mGalleryCompressionPref.setChecked(b);
 			return true;
 		}
 		return false;

--- a/app/src/main/java/moe/feng/nhentai/util/Settings.java
+++ b/app/src/main/java/moe/feng/nhentai/util/Settings.java
@@ -10,7 +10,8 @@ public class Settings {
 
 	public static final String KEY_CELEBRATE = "celebrate", KEY_CARDS_COUNT = "cards_number",
 			KEY_LIST_HD_IMAGE = "list_hd_image", KEY_FULL_IMAGE_PREVIEW = "full_image_preview",
-			KEY_NO_MEDIA = "no_media_boolean", KEY_ALLOW_STANDALONE_TASK = "allow_standalone_task";
+			KEY_NO_MEDIA = "no_media_boolean", KEY_ALLOW_STANDALONE_TASK = "allow_standalone_task",
+			KEY_GALLERY_COMPRESSION = "gallery_compression";
 
 	private static Settings sInstance;
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,9 @@
     <string name="category_details">Info page</string>
     <string name="set_title_full_image_in_details">Load Full HD images as preview</string>
     <string name="set_title_full_image_in_details_summary">It will consume plenty of data and memory.</string>
+    <string name="category_gallery">Gallery</string>
+    <string name="set_title_image_compression_in_gallery">Compress images in gallery</string>
+    <string name="set_title_image_compression_in_gallery_summary">Saves data and memory.</string>
     <string name="set_title_allow_standalone_task">Allow standalone task</string>
     <string name="set_title_allow_standalone_task_desc">Each Book will be shown as a standalone task.</string>
     <string name="set_title_android_too_old_desc">This feature isn\'t supported on your Android version</string>

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -28,4 +28,11 @@
 
 	</PreferenceCategory>
 
+	<PreferenceCategory android:key="gallery" android:title="@string/category_gallery">
+		<moe.feng.nhentai.view.pref.SwitchPreference
+			android:key="gallery_image_compression"
+			android:title="@string/set_title_image_compression_in_gallery"
+			android:summary="@string/set_title_image_compression_in_gallery_summary"/>
+	</PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
The calculateInSampleSize greatly affected image quality for PNG images on high DPI screens. The image was noticably terrible.

Before this commit:
![](http://i.imgur.com/kHHX7SS.jpg)

After this commit:
![](http://i.imgur.com/xv7v387.jpg)

As this option could affect performance, I added a setting for it in Settings -> Appearance.

![](http://i.imgur.com/jfn61UT.png)